### PR TITLE
feat: add status workflow reporting repo template/fork/visibility

### DIFF
--- a/.github/actions/get-repo-info/action.yml
+++ b/.github/actions/get-repo-info/action.yml
@@ -1,0 +1,50 @@
+--- # Retrieve template, fork, and visibility status for the current repository
+name: "Get Repository Info"
+description: "Checks whether the current repository is a template, is a fork (and its parent), and its visibility"
+
+inputs:
+  github-token:
+    description: "GitHub token for API access"
+    required: true
+
+outputs:
+  is_template:
+    description: "Whether the repository is a template repository ('true' or 'false')"
+    value: ${{steps.check.outputs.is_template}}
+  is_fork:
+    description: "Whether the repository is a fork ('true' or 'false')"
+    value: ${{steps.check.outputs.is_fork}}
+  fork_parent:
+    description: "Full name (owner/repo) of the parent repository if this is a fork, otherwise empty"
+    value: ${{steps.check.outputs.fork_parent}}
+  is_public:
+    description: "Whether the repository is public ('true' or 'false')"
+    value: ${{steps.check.outputs.is_public}}
+
+runs:
+  using: composite
+  steps:
+    - name: "Get Repository Info"
+      id: check
+      uses: actions/github-script@v9.0.0
+      with:
+        github-token: ${{inputs.github-token}}
+        script: |
+          const { data: repo } = await github.rest.repos.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          });
+
+          const isPublic = !repo.private;
+          const isTemplate = !!repo.is_template;
+          const isFork = !!repo.fork;
+          const forkParent = isFork && repo.parent ? repo.parent.full_name : '';
+
+          core.info(`Template repository: ${isTemplate ? '✅ Yes' : '❌ No'}`);
+          core.info(`Forked repository: ${isFork ? `✅ Yes (from ${forkParent})` : '❌ No'}`);
+          core.info(`Visibility: ${isPublic ? '🌐 Public' : '🔒 Private'}`);
+
+          core.setOutput('is_template', isTemplate ? 'true' : 'false');
+          core.setOutput('is_fork', isFork ? 'true' : 'false');
+          core.setOutput('fork_parent', forkParent);
+          core.setOutput('is_public', isPublic ? 'true' : 'false');

--- a/.github/actions/get-repo-info/action.yml
+++ b/.github/actions/get-repo-info/action.yml
@@ -20,6 +20,9 @@ outputs:
   is_public:
     description: "Whether the repository is public ('true' or 'false')"
     value: ${{steps.check.outputs.is_public}}
+  lookup_error:
+    description: "Error message if the lookup failed, otherwise empty. On failure other outputs default to the most restrictive values (false/empty)"
+    value: ${{steps.check.outputs.lookup_error}}
 
 runs:
   using: composite
@@ -30,10 +33,21 @@ runs:
       with:
         github-token: ${{inputs.github-token}}
         script: |
-          const { data: repo } = await github.rest.repos.get({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-          });
+          let repo;
+          try {
+            ({ data: repo } = await github.rest.repos.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            }));
+          } catch (err) {
+            core.warning(`⚠️ Could not retrieve repository info — defaulting to restrictive values: ${err.message}`);
+            core.setOutput('is_template', 'false');
+            core.setOutput('is_fork', 'false');
+            core.setOutput('fork_parent', '');
+            core.setOutput('is_public', 'false');
+            core.setOutput('lookup_error', err.message);
+            return;
+          }
 
           const isPublic = !repo.private;
           const isTemplate = !!repo.is_template;
@@ -48,3 +62,4 @@ runs:
           core.setOutput('is_fork', isFork ? 'true' : 'false');
           core.setOutput('fork_parent', forkParent);
           core.setOutput('is_public', isPublic ? 'true' : 'false');
+          core.setOutput('lookup_error', '');

--- a/.github/workflows/status.yml
+++ b/.github/workflows/status.yml
@@ -1,0 +1,63 @@
+--- # Report template, fork, and visibility status for this repository
+name: "Status"
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "0 6 * * *"
+  push:
+    branches:
+      - "**"
+    paths:
+      - ".github/workflows/status.yml"
+
+concurrency:
+  group: "status-${{github.ref}}"
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  status:
+    name: "Status"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Source"
+        uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: "Get Repository Info"
+        id: repo-info
+        uses: ./.github/actions/get-repo-info
+        with:
+          github-token: ${{github.token}}
+
+      - name: "Show Summary"
+        uses: actions/github-script@v9.0.0
+        env:
+          IS_TEMPLATE: ${{steps.repo-info.outputs.is_template}}
+          IS_FORK: ${{steps.repo-info.outputs.is_fork}}
+          FORK_PARENT: ${{steps.repo-info.outputs.fork_parent}}
+          IS_PUBLIC: ${{steps.repo-info.outputs.is_public}}
+        with:
+          script: |
+            const isTemplate = process.env.IS_TEMPLATE === 'true';
+            const isFork = process.env.IS_FORK === 'true';
+            const forkParent = process.env.FORK_PARENT;
+            const isPublic = process.env.IS_PUBLIC === 'true';
+
+            core.summary
+              .addHeading('Repository Status')
+              .addTable([
+                [{data: 'Property', header: true}, {data: 'Value', header: true}],
+                ['Template repository', isTemplate ? '✅ Yes' : '❌ No'],
+                ['Forked repository', isFork ? `✅ Yes (from ${forkParent})` : '❌ No'],
+                ['Visibility', isPublic ? '🌐 Public' : '🔒 Private'],
+              ])
+              .write();
+
+            core.info(`Template repository: ${isTemplate ? '✅ Yes' : '❌ No'}`);
+            core.info(`Forked repository: ${isFork ? `✅ Yes (from ${forkParent})` : '❌ No'}`);
+            core.info(`Visibility: ${isPublic ? '🌐 Public' : '🔒 Private'}`);

--- a/.github/workflows/status.yml
+++ b/.github/workflows/status.yml
@@ -41,12 +41,14 @@ jobs:
           IS_FORK: ${{steps.repo-info.outputs.is_fork}}
           FORK_PARENT: ${{steps.repo-info.outputs.fork_parent}}
           IS_PUBLIC: ${{steps.repo-info.outputs.is_public}}
+          LOOKUP_ERROR: ${{steps.repo-info.outputs.lookup_error}}
         with:
           script: |
             const isTemplate = process.env.IS_TEMPLATE === 'true';
             const isFork = process.env.IS_FORK === 'true';
             const forkParent = process.env.FORK_PARENT;
             const isPublic = process.env.IS_PUBLIC === 'true';
+            const lookupError = process.env.LOOKUP_ERROR;
 
             core.summary
               .addHeading('Repository Status')
@@ -61,3 +63,7 @@ jobs:
             core.info(`Template repository: ${isTemplate ? '✅ Yes' : '❌ No'}`);
             core.info(`Forked repository: ${isFork ? `✅ Yes (from ${forkParent})` : '❌ No'}`);
             core.info(`Visibility: ${isPublic ? '🌐 Public' : '🔒 Private'}`);
+
+            if (lookupError) {
+              core.warning(`⚠️ Repository lookup failed, values above are restrictive defaults: ${lookupError}`);
+            }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Adds a `status` workflow that reports whether this repository is a template, a fork (and its parent), and public/private, via a new reusable composite action.

- **`.github/actions/get-repo-info`** — single `repos.get` call, outputs `is_template`, `is_fork`, `fork_parent`, `is_public`, `lookup_error`.
- **`.github/workflows/status.yml`** — calls the action, then a second `actions/github-script` step renders the values as a job summary table (no PR/issue interaction).
- Triggers: `workflow_dispatch`, daily schedule (`0 6 * * *`), and `push` scoped to changes in the workflow file itself.
- Left the existing `check-repo-visibility` action untouched — it's marked "Maintain in repo: funfair-server-template" (synced externally), so a new local action was added instead of editing it.

## Fail-safe on lookup failure

If the `repos.get` call itself errors (bad token scope, transient API failure, etc.), `get-repo-info` now defaults every output to the most restrictive value (`is_public=false`, `is_template=false`, `is_fork=false`, `fork_parent=''`) and surfaces the error via a new `lookup_error` output plus a `core.warning`. Rationale: this data is meant to gate behaviour that isn't available/allowed on private repos, so assuming "public" on an unknown/failed read is the one wrong guess that causes real damage (attempting something disallowed); assuming "private" on a failed read just over-degrades harmlessly. Callers that need to hard-fail instead of silently degrading can check `lookup_error` for a non-empty value.

## Design decision: no cross-run caching

Considered whether to cache the repo-info result across workflow runs (relevant if this action is later distributed to other repos and called from multiple workflows). Decided against it:

- **Freshness beats efficiency here.** Template/fork/visibility status can change fairly often, and this data is intended to gate behaviour (e.g. skipping steps unavailable on private repos). A stale cached value is a correctness bug, not just wasted work — it could cause a run to attempt something disallowed, or wrongly skip something that's fine.
- **No rate-limit pressure to relieve.** `GITHUB_TOKEN` rate limits are scoped per repository, not pooled across a fleet. Even with hundreds of workflow runs firing concurrently across many repos, each has its own isolated quota — there's no shared bucket for caching to protect.
- **No same-run redundancy to eliminate.** If multiple workflows in a repo call this independently-triggered (different events/schedules), there's no single run to hoist the check into via job outputs or a `workflow_call` gate — each genuinely needs its own fresh read.
- **`actions/cache` is the wrong tool anyway** for this shape of data — it's content-addressed, immutable per key, branch-scoped, and evicted after 7 days of no access. A repo/environment variable would be the correct persistent store *if* caching were ever justified, but the above means it isn't.

Follow-up idea (not yet implemented, flagged for discussion): if this action is reused to gate private-repo-only behaviour, default to the *restrictive* branch on lookup failure (treat an API error as "private/unknown" rather than "public") so a transient failure can't cause a run to attempt something disallowed.

## How Has This Been Tested

- [x] `actionlint` and the repo's pre-commit hooks (yamllint, actionlint, composite-action-lint) pass on both new files.
- [ ] All unit tests pass.
- [ ] All integration tests pass.
- [ ] Manual Testing:
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? --->
<!--- Put an 'x' in all the boxes that apply: --->
<!-- Note that you can just click these after submission -->
<!-- and it will remember the tick for you -->
- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Additional Unit Tests\Integration Tests
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
  functionality to change)
- [ ] Removed no-longer used code

## Deployment Configuration Changes

- [ ] Requires deployment configuration changes as specified below and in CHANGELOG.md
<!--- Insert Deployment configuration changes here -->

## Checklist

<!--- Go over all the following points, and put an 'x' in all --->
<!--- the boxes once they are true. --->
<!-- Note that you can just click these after submission -->
<!-- and it will remember the tick for you -->
- [ ] I have added tests to cover my changes.
- [ ] Unreleased section of CHANGELOG.md has been updated with details of this PR.
